### PR TITLE
do not merge(debugging pr): 

### DIFF
--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -394,6 +394,7 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	req, resp := s.S3.HeadObjectRequest(&head)
 	err := req.Send()
 	if err != nil {
+		s3Log.Debug("leaving headblob error")
 		return nil, mapAwsError(err)
 	}
 	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -393,46 +393,46 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	head := s3.HeadObjectInput{Bucket: &s.bucket,
-		Key: &param.Key,
-	}
-	if s.config.SseC != "" {
-		head.SSECustomerAlgorithm = PString("AES256")
-		head.SSECustomerKey = &s.config.SseC
-		head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	}
+	// head := s3.HeadObjectInput{Bucket: &s.bucket,
+	// 	Key: &param.Key,
+	// }
+	// if s.config.SseC != "" {
+	// 	head.SSECustomerAlgorithm = PString("AES256")
+	// 	head.SSECustomerKey = &s.config.SseC
+	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	// }
 
-	req, resp := s.S3.HeadObjectRequest(&head)
-	err := req.Send()
-	if err != nil {
-		s3Log.Debug("leaving headblob error")
-		return nil, mapAwsError(err)
-	}
-	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	s3Log.Debugf("Etag:%v, LastModified:%v, Size:%v, SC:%v, ContentType:%v, RequestId:%v",
-		resp.ETag, resp.LastModified, uint64(*resp.ContentLength), resp.StorageClass, resp.ContentType, s.getRequestId(req))
-	s3Log.Debugf("Resp.Metadata below")
-	for key, value := range resp.Metadata {
-		if value != nil {
-			s3Log.Debugf("%s: %s", key, *value)
-		} else {
-			s3Log.Debugf("%s: <nil>\n", key)
-		}
-	}
-	s3Log.Debugf("Exiting Headblob")
-	return &HeadBlobOutput{
-		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
-			ETag:         resp.ETag,
-			LastModified: resp.LastModified,
-			Size:         uint64(*resp.ContentLength),
-			StorageClass: resp.StorageClass,
-		},
-		ContentType: resp.ContentType,
-		Metadata:    metadataToLower(resp.Metadata),
-		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-		RequestId:   s.getRequestId(req),
-	}, nil
+	// req, resp := s.S3.HeadObjectRequest(&head)
+	// err := req.Send()
+	// if err != nil {
+	// 	s3Log.Debug("leaving headblob error")
+	// 	return nil, mapAwsError(err)
+	// }
+	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	// s3Log.Debugf("Etag:%v, LastModified:%v, Size:%v, SC:%v, ContentType:%v, RequestId:%v",
+	// 	resp.ETag, resp.LastModified, uint64(*resp.ContentLength), resp.StorageClass, resp.ContentType, s.getRequestId(req))
+	// s3Log.Debugf("Resp.Metadata below")
+	// for key, value := range resp.Metadata {
+	// 	if value != nil {
+	// 		s3Log.Debugf("%s: %s", key, *value)
+	// 	} else {
+	// 		s3Log.Debugf("%s: <nil>\n", key)
+	// 	}
+	// }
+	// s3Log.Debugf("Exiting Headblob")
+	// return &HeadBlobOutput{
+	// 	BlobItemOutput: BlobItemOutput{
+	// 		Key:          &param.Key,
+	// 		ETag:         resp.ETag,
+	// 		LastModified: resp.LastModified,
+	// 		Size:         uint64(*resp.ContentLength),
+	// 		StorageClass: resp.StorageClass,
+	// 	},
+	// 	ContentType: resp.ContentType,
+	// 	Metadata:    metadataToLower(resp.Metadata),
+	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+	// 	RequestId:   s.getRequestId(req),
+	// }, nil
 
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -390,44 +390,44 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	// head := s3.HeadObjectInput{Bucket: &s.bucket,
-	// 	Key: &param.Key,
-	// }
-	// if s.config.SseC != "" {
-	// 	head.SSECustomerAlgorithm = PString("AES256")
-	// 	head.SSECustomerKey = &s.config.SseC
-	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	// }
+	head := s3.HeadObjectInput{Bucket: &s.bucket,
+		Key: &param.Key,
+	}
+	if s.config.SseC != "" {
+		head.SSECustomerAlgorithm = PString("AES256")
+		head.SSECustomerKey = &s.config.SseC
+		head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	}
 
-	// req, resp := s.S3.HeadObjectRequest(&head)
-	// err := req.Send()
-	// if err != nil {
-	// 	s3Log.Debug("leaving headblob error")
-	// 	return nil, mapAwsError(err)
-	// }
-	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	// s3Log.Debugf("Resp.Metadata below")
-	// for key, value := range resp.Metadata {
-	// 	if value != nil {
-	// 		s3Log.Debugf("%s: %s", key, *value)
-	// 	} else {
-	// 		s3Log.Debugf("%s: <nil>\n", key)
-	// 	}
-	// }
-	// s3Log.Debugf("Exiting Headblob")
-	// return &HeadBlobOutput{
-	// 	BlobItemOutput: BlobItemOutput{
-	// 		Key:          &param.Key,
-	// 		ETag:         resp.ETag,
-	// 		LastModified: resp.LastModified,
-	// 		Size:         uint64(*resp.ContentLength),
-	// 		StorageClass: resp.StorageClass,
-	// 	},
-	// 	ContentType: resp.ContentType,
-	// 	Metadata:    metadataToLower(resp.Metadata),
-	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-	// 	RequestId:   s.getRequestId(req),
-	// }, nil
+	req, resp := s.S3.HeadObjectRequest(&head)
+	err := req.Send()
+	if err != nil {
+		s3Log.Debug("leaving headblob error")
+		return nil, mapAwsError(err)
+	}
+	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	s3Log.Debugf("Resp.Metadata below")
+	for key, value := range resp.Metadata {
+		if value != nil {
+			s3Log.Debugf("%s: %s", key, *value)
+		} else {
+			s3Log.Debugf("%s: <nil>\n", key)
+		}
+	}
+	s3Log.Debugf("Exiting Headblob")
+	return &HeadBlobOutput{
+		BlobItemOutput: BlobItemOutput{
+			Key:          &param.Key,
+			ETag:         resp.ETag,
+			LastModified: resp.LastModified,
+			Size:         uint64(*resp.ContentLength),
+			StorageClass: resp.StorageClass,
+		},
+		ContentType: resp.ContentType,
+		Metadata:    metadataToLower(resp.Metadata),
+		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+		RequestId:   s.getRequestId(req),
+	}, nil
 
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -381,7 +381,6 @@ func (m *HeadBlobInput) cloneHead() *HeadBlobInput {
 // It just hard stops after the top directory, `jose` and doesnt go to `jose/` etc
 func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	s3Log.Debugf("Entering HeadBlob")
-	s3Log.Debug("ORIGINAL PARAM.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
 	// Temporarily revert to old implementation
 	// This is so we can test the `listblob` implemetation, without needing to navigate there first.
 	// Once we fix being able to read without navigation first we can address not being able to open the file
@@ -396,7 +395,7 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	blah := s.bucket + param.Key
 	bblah2 := os.Getenv("BUCKET_HOST")
 	s3Log.Debug("New Key:" + blah + " and host:" + bblah2)
-	head := s3.HeadObjectInput{Bucket: &bblah2,
+	head := s3.HeadObjectInput{Bucket: &s.bucket,
 		Key: &blah, // try using this
 	}
 	if s.config.SseC != "" {

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -789,6 +789,7 @@ func getDate(resp *http.Response) *time.Time {
 }
 
 func (s *S3Backend) PutBlob(param *PutBlobInput) (*PutBlobOutput, error) {
+	s3Log.Debugf("Entering PutBlob")
 	storageClass := s.config.StorageClass
 	if param.Size != nil && *param.Size < 128*1024 && storageClass == "STANDARD_IA" {
 		storageClass = "STANDARD"
@@ -823,7 +824,7 @@ func (s *S3Backend) PutBlob(param *PutBlobInput) (*PutBlobOutput, error) {
 	if err != nil {
 		return nil, mapAwsError(err)
 	}
-
+	s3Log.Debug("Exiting Putblob")
 	return &PutBlobOutput{
 		ETag:         resp.ETag,
 		LastModified: getDate(req.HTTPResponse),

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -381,46 +381,51 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	head := s3.HeadObjectInput{Bucket: &s.bucket,
-		Key: &param.Key,
-	}
-	if s.config.SseC != "" {
-		head.SSECustomerAlgorithm = PString("AES256")
-		head.SSECustomerKey = &s.config.SseC
-		head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	}
+	// head := s3.HeadObjectInput{Bucket: &s.bucket,
+	// 	Key: &param.Key,
+	// }
+	// if s.config.SseC != "" {
+	// 	head.SSECustomerAlgorithm = PString("AES256")
+	// 	head.SSECustomerKey = &s.config.SseC
+	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	// }
 
-	req, resp := s.S3.HeadObjectRequest(&head)
-	err := req.Send()
-	if err != nil {
-		return nil, mapAwsError(err)
-	}
-	s3Log.Debugf("Exiting Headblob")
-	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	s3Log.Debugf("Resp.Metadata:%v", resp.Metadata)
-	return &HeadBlobOutput{
-		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
-			ETag:         resp.ETag,
-			LastModified: resp.LastModified,
-			Size:         uint64(*resp.ContentLength),
-			StorageClass: resp.StorageClass,
-		},
-		ContentType: resp.ContentType,
-		Metadata:    metadataToLower(resp.Metadata),
-		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-		RequestId:   s.getRequestId(req),
-	}, nil
+	// req, resp := s.S3.HeadObjectRequest(&head)
+	// err := req.Send()
+	// if err != nil {
+	// 	return nil, mapAwsError(err)
+	// }
+	// s3Log.Debugf("Exiting Headblob")
+	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	// s3Log.Debugf("Resp.Metadata:%v", resp.Metadata)
+	// return &HeadBlobOutput{
+	// 	BlobItemOutput: BlobItemOutput{
+	// 		Key:          &param.Key,
+	// 		ETag:         resp.ETag,
+	// 		LastModified: resp.LastModified,
+	// 		Size:         uint64(*resp.ContentLength),
+	// 		StorageClass: resp.StorageClass,
+	// 	},
+	// 	ContentType: resp.ContentType,
+	// 	Metadata:    metadataToLower(resp.Metadata),
+	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+	// 	RequestId:   s.getRequestId(req),
+	// }, nil
+
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting
+	// So the question here is WHY does this not end up going into listblob?
 	cleanedPath := returnURIPath(s.bucket + param.Key)
 	etag, lastModified, size, storageClass, contentType, amzRequest, amzMeta, _ := s.sendRequest("HEAD", cleanedPath)
 
-	s3Log.Debugf("Exiting Headblob")
+	// Why is param.key here just `jose` when above its jose/valid/jose-test.txt
 	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	blah := "jose/valid/jose-test.txt"
+	//s3Log.Debugf("Resp.Metadata:%v", amzMeta)
+	s3Log.Debugf("Exiting Headblob")
 	return &HeadBlobOutput{
 		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
+			Key:          &blah,
 			ETag:         &etag,
 			LastModified: &lastModified,
 			Size:         size,

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -382,44 +382,44 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	head := s3.HeadObjectInput{Bucket: &s.bucket,
-		Key: &param.Key,
-	}
-	if s.config.SseC != "" {
-		head.SSECustomerAlgorithm = PString("AES256")
-		head.SSECustomerKey = &s.config.SseC
-		head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	}
+	// head := s3.HeadObjectInput{Bucket: &s.bucket,
+	// 	Key: &param.Key,
+	// }
+	// if s.config.SseC != "" {
+	// 	head.SSECustomerAlgorithm = PString("AES256")
+	// 	head.SSECustomerKey = &s.config.SseC
+	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	// }
 
-	req, resp := s.S3.HeadObjectRequest(&head)
-	err := req.Send()
-	if err != nil {
-		s3Log.Debug("leaving headblob error")
-		return nil, mapAwsError(err)
-	}
-	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	s3Log.Debugf("Resp.Metadata below")
-	for key, value := range resp.Metadata {
-		if value != nil {
-			s3Log.Debugf("%s: %s", key, *value)
-		} else {
-			s3Log.Debugf("%s: <nil>\n", key)
-		}
-	}
-	s3Log.Debugf("Exiting Headblob")
-	return &HeadBlobOutput{
-		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
-			ETag:         resp.ETag,
-			LastModified: resp.LastModified,
-			Size:         uint64(*resp.ContentLength),
-			StorageClass: resp.StorageClass,
-		},
-		ContentType: resp.ContentType,
-		Metadata:    metadataToLower(resp.Metadata),
-		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-		RequestId:   s.getRequestId(req),
-	}, nil
+	// req, resp := s.S3.HeadObjectRequest(&head)
+	// err := req.Send()
+	// if err != nil {
+	// 	s3Log.Debug("leaving headblob error")
+	// 	return nil, mapAwsError(err)
+	// }
+	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	// s3Log.Debugf("Resp.Metadata below")
+	// for key, value := range resp.Metadata {
+	// 	if value != nil {
+	// 		s3Log.Debugf("%s: %s", key, *value)
+	// 	} else {
+	// 		s3Log.Debugf("%s: <nil>\n", key)
+	// 	}
+	// }
+	// s3Log.Debugf("Exiting Headblob")
+	// return &HeadBlobOutput{
+	// 	BlobItemOutput: BlobItemOutput{
+	// 		Key:          &param.Key,
+	// 		ETag:         resp.ETag,
+	// 		LastModified: resp.LastModified,
+	// 		Size:         uint64(*resp.ContentLength),
+	// 		StorageClass: resp.StorageClass,
+	// 	},
+	// 	ContentType: resp.ContentType,
+	// 	Metadata:    metadataToLower(resp.Metadata),
+	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+	// 	RequestId:   s.getRequestId(req),
+	// }, nil
 
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -395,6 +395,7 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 
 	blah := s.bucket + "/" + param.Key
 	bblah2 := os.Getenv("BUCKET_HOST")
+	s3Log.Debug("New Key:" + blah + " and host:" + bblah2)
 	head := s3.HeadObjectInput{Bucket: &bblah2,
 		Key: &blah, // try using this
 	}
@@ -424,7 +425,8 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	s3Log.Debugf("Exiting Headblob")
 	return &HeadBlobOutput{
 		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
+			//Key:          &param.Key,
+			Key:          &blah, // does this need to be deep copied
 			ETag:         resp.ETag,
 			LastModified: resp.LastModified,
 			Size:         uint64(*resp.ContentLength),

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -393,7 +393,7 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	blah := s.bucket + "/" + param.Key
+	blah := s.bucket + param.Key
 	bblah2 := os.Getenv("BUCKET_HOST")
 	s3Log.Debug("New Key:" + blah + " and host:" + bblah2)
 	head := s3.HeadObjectInput{Bucket: &bblah2,

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -382,43 +382,43 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	// head := s3.HeadObjectInput{Bucket: &s.bucket,
-	// 	Key: &param.Key,
-	// }
-	// if s.config.SseC != "" {
-	// 	head.SSECustomerAlgorithm = PString("AES256")
-	// 	head.SSECustomerKey = &s.config.SseC
-	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	// }
+	head := s3.HeadObjectInput{Bucket: &s.bucket,
+		Key: &param.Key,
+	}
+	if s.config.SseC != "" {
+		head.SSECustomerAlgorithm = PString("AES256")
+		head.SSECustomerKey = &s.config.SseC
+		head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	}
 
-	// req, resp := s.S3.HeadObjectRequest(&head)
-	// err := req.Send()
-	// if err != nil {
-	// 	return nil, mapAwsError(err)
-	// }
-	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	// s3Log.Debugf("Resp.Metadata below")
-	// for key, value := range resp.Metadata {
-	// 	if value != nil {
-	// 		s3Log.Debugf("%s: %s", key, *value)
-	// 	} else {
-	// 		s3Log.Debugf("%s: <nil>\n", key)
-	// 	}
-	// }
-	// s3Log.Debugf("Exiting Headblob")
-	// return &HeadBlobOutput{
-	// 	BlobItemOutput: BlobItemOutput{
-	// 		Key:          &param.Key,
-	// 		ETag:         resp.ETag,
-	// 		LastModified: resp.LastModified,
-	// 		Size:         uint64(*resp.ContentLength),
-	// 		StorageClass: resp.StorageClass,
-	// 	},
-	// 	ContentType: resp.ContentType,
-	// 	Metadata:    metadataToLower(resp.Metadata),
-	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-	// 	RequestId:   s.getRequestId(req),
-	// }, nil
+	req, resp := s.S3.HeadObjectRequest(&head)
+	err := req.Send()
+	if err != nil {
+		return nil, mapAwsError(err)
+	}
+	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	s3Log.Debugf("Resp.Metadata below")
+	for key, value := range resp.Metadata {
+		if value != nil {
+			s3Log.Debugf("%s: %s", key, *value)
+		} else {
+			s3Log.Debugf("%s: <nil>\n", key)
+		}
+	}
+	s3Log.Debugf("Exiting Headblob")
+	return &HeadBlobOutput{
+		BlobItemOutput: BlobItemOutput{
+			Key:          &param.Key,
+			ETag:         resp.ETag,
+			LastModified: resp.LastModified,
+			Size:         uint64(*resp.ContentLength),
+			StorageClass: resp.StorageClass,
+		},
+		ContentType: resp.ContentType,
+		Metadata:    metadataToLower(resp.Metadata),
+		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+		RequestId:   s.getRequestId(req),
+	}, nil
 
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -378,6 +378,7 @@ func (m *HeadBlobInput) cloneHead() *HeadBlobInput {
 }
 func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	s3Log.Debugf("Entering HeadBlob")
+	s3Log.Debug("ORIGINAL PARAM.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
 	// Temporarily revert to old implementation
 	// This is so we can test the `listblob` implemetation, without needing to navigate there first.
 	// Once we fix being able to read without navigation first we can address not being able to open the file
@@ -438,7 +439,7 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 
 	// Why is param.key here just `jose` when above its jose/valid/jose-test.txt
 	s3Log.Debug("ClonedParam.Key:" + clonedParam.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(clonedParam.Key, "/")))
-	s3Log.Debug("ORIGINAL PARAM.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+
 	//blah := "jose/valid/jose-test.txt" // hardcoding didnt do anything
 	s3Log.Debugf("Resp.Metadata below")
 	for key, value := range amzMeta {

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -230,6 +230,7 @@ func (s *S3Backend) detectBucketLocationByHEAD() (err error, isAws bool) {
 }
 
 func (s *S3Backend) testBucket(key string) (err error) {
+	s3Log.Debug("Entering testBucket")
 	_, err = s.HeadBlob(&HeadBlobInput{Key: key})
 	if err != nil {
 		if err == fuse.ENOENT {
@@ -381,43 +382,43 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	// leading to permission denied, since old headblob isnt able to handle special characters
 	// So we need to fix our `fixed` headblob converting.
 
-	head := s3.HeadObjectInput{Bucket: &s.bucket,
-		Key: &param.Key,
-	}
-	if s.config.SseC != "" {
-		head.SSECustomerAlgorithm = PString("AES256")
-		head.SSECustomerKey = &s.config.SseC
-		head.SSECustomerKeyMD5 = &s.config.SseCDigest
-	}
+	// head := s3.HeadObjectInput{Bucket: &s.bucket,
+	// 	Key: &param.Key,
+	// }
+	// if s.config.SseC != "" {
+	// 	head.SSECustomerAlgorithm = PString("AES256")
+	// 	head.SSECustomerKey = &s.config.SseC
+	// 	head.SSECustomerKeyMD5 = &s.config.SseCDigest
+	// }
 
-	req, resp := s.S3.HeadObjectRequest(&head)
-	err := req.Send()
-	if err != nil {
-		return nil, mapAwsError(err)
-	}
-	s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
-	s3Log.Debugf("Resp.Metadata below")
-	for key, value := range resp.Metadata {
-		if value != nil {
-			s3Log.Debugf("%s: %s", key, *value)
-		} else {
-			s3Log.Debugf("%s: <nil>\n", key)
-		}
-	}
-	s3Log.Debugf("Exiting Headblob")
-	return &HeadBlobOutput{
-		BlobItemOutput: BlobItemOutput{
-			Key:          &param.Key,
-			ETag:         resp.ETag,
-			LastModified: resp.LastModified,
-			Size:         uint64(*resp.ContentLength),
-			StorageClass: resp.StorageClass,
-		},
-		ContentType: resp.ContentType,
-		Metadata:    metadataToLower(resp.Metadata),
-		IsDirBlob:   strings.HasSuffix(param.Key, "/"),
-		RequestId:   s.getRequestId(req),
-	}, nil
+	// req, resp := s.S3.HeadObjectRequest(&head)
+	// err := req.Send()
+	// if err != nil {
+	// 	return nil, mapAwsError(err)
+	// }
+	// s3Log.Debug("Param.Key:" + param.Key + "\nIsDirBlob:" + strconv.FormatBool(strings.HasSuffix(param.Key, "/")))
+	// s3Log.Debugf("Resp.Metadata below")
+	// for key, value := range resp.Metadata {
+	// 	if value != nil {
+	// 		s3Log.Debugf("%s: %s", key, *value)
+	// 	} else {
+	// 		s3Log.Debugf("%s: <nil>\n", key)
+	// 	}
+	// }
+	// s3Log.Debugf("Exiting Headblob")
+	// return &HeadBlobOutput{
+	// 	BlobItemOutput: BlobItemOutput{
+	// 		Key:          &param.Key,
+	// 		ETag:         resp.ETag,
+	// 		LastModified: resp.LastModified,
+	// 		Size:         uint64(*resp.ContentLength),
+	// 		StorageClass: resp.StorageClass,
+	// 	},
+	// 	ContentType: resp.ContentType,
+	// 	Metadata:    metadataToLower(resp.Metadata),
+	// 	IsDirBlob:   strings.HasSuffix(param.Key, "/"),
+	// 	RequestId:   s.getRequestId(req),
+	// }, nil
 
 	// New implementation below, this breaks and when trying to read a file on initial load (before navigating)
 	// Will convert a "folder" into a "file" making it impossible to navigate to without restarting
@@ -921,7 +922,7 @@ func (s *S3Backend) sendRequest(method string, cleanedPath string) (string, time
 		}
 	}
 	// Debug Response
-	s3Log.Debug("Status Code:" + strconv.Itoa(res.StatusCode))
+	s3Log.Debug("Our Status Code:" + strconv.Itoa(res.StatusCode))
 	s3Log.Debug("ContentType:" + contentType)
 	s3Log.Debug("ContentLength:" + res.Header.Get("ContentLength"))
 	return etag, lastModified, size, storageClass, contentType, amzRequest, amzMeta, io.NopCloser(res.Body)

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1296,7 +1296,8 @@ func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc 
 	key = appendChildName(key, name)
 	s3Log.Debugf("Key:%s and name:%s", key, name)
 	params := &HeadBlobInput{Key: key}
-	params = &HeadBlobInput{Key: "jose/valid/jose-test.txt"} // can try hardcoding here
+	// params = &HeadBlobInput{Key: "jose/valid/jose-test.txt"} // can try hardcoding here
+	// this hardcode doesnt fix it even just trying to just access it
 	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
 	resp, err := cloud.HeadBlob(params)
 	if err != nil {

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1291,6 +1291,7 @@ func (parent *Inode) readDirFromCache(offset fuseops.DirOffset) (en *DirHandleEn
 
 func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc chan error) {
 	cloud, key := parent.cloud() // check inside this parent.cloud what happens, this sets the key to be off
+	// so by this point after 1293 parent.cloud the damage has been done
 	// essentially the `key` that is being returned here is not working. it returns empty w. the new imp of headblob
 	s3Log.Debugf("1st pre append Key:%s and name:%s", key, name)
 	// for whatever reason with our new getblob the key thats generated here is just `jose`
@@ -1300,7 +1301,9 @@ func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc 
 	// params = &HeadBlobInput{Key: "jose/valid/jose-test.txt"} // can try hardcoding here
 	// this hardcode doesnt fix it even just trying to just access it
 	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
-	resp, err := cloud.HeadBlob(params)
+	resp, err := cloud.HeadBlob(params) // we call headblob here and the implementation of headblob MATTERS
+	// the old implementation "works" but new does not.
+	// also the only call to headblob that is used
 	if err != nil {
 		s3Log.Debug("inside lookupinodenotdir error")
 		errc <- mapAwsError(err)

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1078,6 +1078,7 @@ func (parent *Inode) Rename(from string, newParent *Inode, to string) (err error
 	}
 
 	if fromIsDir && !toIsDir {
+		s3Log.Debug("Inside dir.go/rename before headblob call")
 		_, err = fromCloud.HeadBlob(&HeadBlobInput{
 			Key: toFullName,
 		})
@@ -1292,6 +1293,7 @@ func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc 
 	cloud, key := parent.cloud()
 	key = appendChildName(key, name)
 	params := &HeadBlobInput{Key: key}
+	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
 	resp, err := cloud.HeadBlob(params)
 	if err != nil {
 		errc <- mapAwsError(err)

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1291,6 +1291,7 @@ func (parent *Inode) readDirFromCache(offset fuseops.DirOffset) (en *DirHandleEn
 
 func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc chan error) {
 	cloud, key := parent.cloud() // check inside this parent.cloud what happens, this sets the key to be off
+	// essentially the `key` that is being returned here is not working. it returns empty w. the new imp of headblob
 	s3Log.Debugf("1st pre append Key:%s and name:%s", key, name)
 	// for whatever reason with our new getblob the key thats generated here is just `jose`
 	key = appendChildName(key, name)

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1296,10 +1296,11 @@ func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc 
 	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
 	resp, err := cloud.HeadBlob(params)
 	if err != nil {
+		s3Log.Debug("inside lookupinodenotdir error")
 		errc <- mapAwsError(err)
 		return
 	}
-
+	s3Log.Debug("Exiting lookupinodenotdir")
 	s3Log.Debug(resp)
 	c <- *resp
 }
@@ -1338,9 +1339,10 @@ func (parent *Inode) LookUpInodeMaybeDir(name string, fullName string) (inode *I
 	if cloud == nil {
 		panic("s3 disabled")
 	}
-
+	s3Log.Debug("Inside lookupinodemaybedir top")
 	go parent.LookUpInodeNotDir(name, objectChan, errObjectChan)
 	if !cloud.Capabilities().DirBlob && !parent.fs.flags.Cheap {
+		s3Log.Debug("Inside lookupinodemaybe dir !cheap")
 		go parent.LookUpInodeNotDir(name+"/", objectChan, errDirBlobChan)
 		if !parent.fs.flags.ExplicitDir {
 			errDirChan = make(chan error, 1)
@@ -1412,6 +1414,7 @@ func (parent *Inode) LookUpInodeMaybeDir(name string, fullName string) (inode *I
 		switch checking {
 		case 2:
 			if parent.fs.flags.Cheap {
+				s3Log.Debug("Inside lookupinodemaybe dir cheap")
 				go parent.LookUpInodeNotDir(name+"/", objectChan, errDirBlobChan)
 			}
 		case 1:

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1290,11 +1290,13 @@ func (parent *Inode) readDirFromCache(offset fuseops.DirOffset) (en *DirHandleEn
 }
 
 func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc chan error) {
-	cloud, key := parent.cloud() // check inside this parent.cloud what happens
+	cloud, key := parent.cloud() // check inside this parent.cloud what happens, this sets the key to be off
 	s3Log.Debugf("1st pre append Key:%s and name:%s", key, name)
+	// for whatever reason with our new getblob the key thats generated here is just `jose`
 	key = appendChildName(key, name)
 	s3Log.Debugf("Key:%s and name:%s", key, name)
 	params := &HeadBlobInput{Key: key}
+	params = &HeadBlobInput{Key: "jose/valid/jose-test.txt"} // can try hardcoding here
 	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
 	resp, err := cloud.HeadBlob(params)
 	if err != nil {

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -1290,8 +1290,10 @@ func (parent *Inode) readDirFromCache(offset fuseops.DirOffset) (en *DirHandleEn
 }
 
 func (parent *Inode) LookUpInodeNotDir(name string, c chan HeadBlobOutput, errc chan error) {
-	cloud, key := parent.cloud()
+	cloud, key := parent.cloud() // check inside this parent.cloud what happens
+	s3Log.Debugf("1st pre append Key:%s and name:%s", key, name)
 	key = appendChildName(key, name)
+	s3Log.Debugf("Key:%s and name:%s", key, name)
 	params := &HeadBlobInput{Key: key}
 	s3Log.Debug("Inside dir.go/LookupInodeNotDir before headblob")
 	resp, err := cloud.HeadBlob(params)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -176,6 +176,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 	}
 
 	for p := dir; p != nil; p = p.Parent {
+		s3Log.Debug("Entering for loop")
 		if p.dir.cloud != nil {
 			cloud = p.dir.cloud
 			// the error backend produces a mount.err file
@@ -197,7 +198,8 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 			}
 			break
 		}
-
+		// with new headblob this 'path' ends up as just the toppest which is wrong.
+		// none of this ends up getting called, none of these s3logdebug get shown
 		if path == "" {
 			path = *p.Name
 			s3Log.Debugf("Path in for loop:%v", path)
@@ -206,6 +208,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 			path = *p.Name + "/" + path
 			s3Log.Debugf("Not prepending if i am already root node path value:%v", path)
 		}
+		s3Log.Debug("Exiting the for loop")
 	}
 
 	if path == "" {

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -222,6 +222,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 	} else {
 		path = prefix + path
 		s3Log.Debugf("Path at ELSE out near end of cloud loop:%v", path)
+		// in a successful headblob it reaches here with jose/valid/jose-test.txt
 	}
 	return
 }

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -184,7 +184,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 			// at the root and is not aware of prefix
 			_, isErr := cloud.(StorageBackendInitError)
 			if !isErr {
-				s3Log.Debug("!isErr first reached")
+				s3Log.Debug("!isErr first reached") // this is reached
 				// we call init here instead of
 				// relying on the wrapper to call init
 				// because we want to return the right
@@ -192,15 +192,15 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 				if c, ok := cloud.(*StorageBackendInitWrapper); ok {
 					err := c.Init("")
 					isErr = err != nil
-					s3Log.Debug("isErr got reset to nnil")
+					s3Log.Debug("isErr got reset to nnil") // not reached
 				}
 			}
 
 			if !isErr {
 				prefix = p.dir.mountPrefix
-				s3Log.Debug("!isErr reached, prefix:" + prefix)
+				s3Log.Debug("!isErr reached, prefix:" + prefix) // this gets reached with empty prefix
 			}
-			s3Log.Debug("Breaking out of for loop, p.dir.cloud not nil")
+			s3Log.Debug("Breaking out of for loop, p.dir.cloud not nil") // this gets reached
 			break
 		}
 		// with new headblob this 'path' ends up as just the toppest which is wrong.
@@ -218,7 +218,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 
 	if path == "" {
 		path = strings.TrimRight(prefix, "/")
-		s3Log.Debugf("Path out near end of cloud loop:%v", path)
+		s3Log.Debugf("Path out near end of cloud loop:%v", path) // this is hit
 	} else {
 		path = prefix + path
 		s3Log.Debugf("Path at ELSE out near end of cloud loop:%v", path)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -178,11 +178,13 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 	for p := dir; p != nil; p = p.Parent {
 		s3Log.Debug("Entering for loop")
 		if p.dir.cloud != nil {
+			s3Log.Debug("p.dir.cloud != nil")
 			cloud = p.dir.cloud
 			// the error backend produces a mount.err file
 			// at the root and is not aware of prefix
 			_, isErr := cloud.(StorageBackendInitError)
 			if !isErr {
+				s3Log.Debug("!isErr first reached")
 				// we call init here instead of
 				// relying on the wrapper to call init
 				// because we want to return the right
@@ -190,12 +192,15 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 				if c, ok := cloud.(*StorageBackendInitWrapper); ok {
 					err := c.Init("")
 					isErr = err != nil
+					s3Log.Debug("isErr got reset to nnil")
 				}
 			}
 
 			if !isErr {
 				prefix = p.dir.mountPrefix
+				s3Log.Debug("!isErr reached, prefix:" + prefix)
 			}
+			s3Log.Debug("Breaking out of for loop, p.dir.cloud not nil")
 			break
 		}
 		// with new headblob this 'path' ends up as just the toppest which is wrong.
@@ -208,7 +213,7 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 			path = *p.Name + "/" + path
 			s3Log.Debugf("Not prepending if i am already root node path value:%v", path)
 		}
-		s3Log.Debug("Exiting the for loop")
+		s3Log.Debug("Exiting the for loop") // doesnt get here
 	}
 
 	if path == "" {

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -344,6 +344,7 @@ func (inode *Inode) fillXattr() (err error) {
 
 		cloud, key := inode.cloud()
 		params := &HeadBlobInput{Key: key}
+		s3Log.Debug("Inside handles.go/fillxattr before headblob")
 		resp, err := cloud.HeadBlob(params)
 		if err != nil {
 			err = mapAwsError(err)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -169,8 +169,10 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 	if inode.dir == nil {
 		path = *inode.Name
 		dir = inode.Parent
+		s3Log.Debug("cloud: Inode dir nil")
 	} else {
 		dir = inode
+		s3Log.Debugf("cloud: inode.dir not nil val:%v", dir)
 	}
 
 	for p := dir; p != nil; p = p.Parent {
@@ -198,16 +200,20 @@ func (inode *Inode) cloud() (cloud StorageBackend, path string) {
 
 		if path == "" {
 			path = *p.Name
+			s3Log.Debugf("Path in for loop:%v", path)
 		} else if p.Parent != nil {
 			// don't prepend if I am already the root node
 			path = *p.Name + "/" + path
+			s3Log.Debugf("Not prepending if i am already root node path value:%v", path)
 		}
 	}
 
 	if path == "" {
 		path = strings.TrimRight(prefix, "/")
+		s3Log.Debugf("Path out near end of cloud loop:%v", path)
 	} else {
 		path = prefix + path
+		s3Log.Debugf("Path at ELSE out near end of cloud loop:%v", path)
 	}
 	return
 }


### PR DESCRIPTION
For https://jirab.statcan.ca/browse/BTIS-912

This PR right now looks at the issue where we **need to navigate to a directory first** before being able to read a file whose name contains special characters in python. Navigating to the directory afterwards fixes this.

**I temporarily revert headblob** because it was found that the 'fixed' implementation does not handle folders correctly, and will turn a `folder` into a `file` in the browser leading us to be unable to debug further / is an extra barrier in testing.

We think the issue here might be with `ListBlob`. After this is fixed and we are able to do something like;
```
f = open("filers/jose/valid/invalid,file.txt", "r")
print(f.read())
```
In python upon notebook startup with no error then we can move onto headblob not working correctly, (though it does allow us to read and open files in directories that dont have a special character in them)